### PR TITLE
Update .dockerignore to not ignore the noto font.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,6 +42,7 @@
 **/*@tmp
 
 openmpf-docker
-!openmpf-docker/openmpf_build/scripts
+!openmpf-docker/openmpf_build
+openmpf-docker/openmpf_build/Dockerfile
 openmpf-components
 openmpf-contrib-components


### PR DESCRIPTION
**Issues:**

- Fixes: openmpf/openmpf/issues/2013

Related PRs:
- https://github.com/openmpf/openmpf-docker/pull/256

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-projects/11)
<!-- Reviewable:end -->
