### PR TITLE
Un-dockerignore noto-emoji-fonts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,7 +42,7 @@
 **/*@tmp
 
 openmpf-docker
-!openmpf-docker/openmpf_build
-openmpf-docker/openmpf_build/Dockerfile
+!openmpf-docker/openmpf_build/scripts
+!openmpf-docker/openmpf_build/noto-emoji-font
 openmpf-components
 openmpf-contrib-components


### PR DESCRIPTION
The copy in openmpf_build/Dockerfile will fail because the noto-emoji-fonts folder will not exist after `COPY . /home/mpf/openmpf-projects`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-projects/13)
<!-- Reviewable:end -->
